### PR TITLE
Test for binary separable data, 200 pts

### DIFF
--- a/tests/torch_tests/test_overfitting_separable.py
+++ b/tests/torch_tests/test_overfitting_separable.py
@@ -7,8 +7,8 @@ ANGLE_TOL = 1e-1 * np.pi
 def generate_points():
     opposites = np.array([[1., 1.], [-1., -1.]])
     data = np.concatenate([
-        opposites[0, :] + np.random.normal(0, 0.1, size=(100, 1)) * np.array([[-1, 1]]),
-        opposites[1, :] + np.random.normal(0, 0.1, size=(100, 1)) * np.array([[-1, 1]])
+        opposites[0, :] + np.random.normal(0, 2, size=(100, 1)) * np.array([[-1, 1]]),
+        opposites[1, :] + np.random.normal(0, 2, size=(100, 1)) * np.array([[-1, 1]])
     ], axis=0)
     labels = np.array([1.] * 100 + [-1.] * 100)
     return data, labels


### PR DESCRIPTION
Simple generation:
Two foci in $\xi_1:=(1, 1)^T$ and $\xi_{-1}:=(-1, -1)^T$, and random perturbations on two **parallel** lines guided by $\vec{n}:=(-1, 1)^T$ and normal noise of variance $4$.
They should be separated by a line with support vector $\theta^*=(1, 1)^T$, so the resulting $\theta$ parameters are compared (in angle) to this vector.