### PR TITLE
Broken IS shutdown for presampledLoss

### DIFF
--- a/skwdro/solvers/entropic_dual_torch.py
+++ b/skwdro/solvers/entropic_dual_torch.py
@@ -169,9 +169,9 @@ def optim_presample(
         if opt_cond(loss, iteration): break
         with pt.no_grad():
             _is = loss.imp_samp
-            loss.imp_samp = not _is
+            loss.imp_samp = False # Shut down IS if it is on.
             losses.append(closure(False))
-            loss.imp_samp = _is
+            loss.imp_samp = _is # Put it back on if it used to be.
             del _is
 
     return losses


### PR DESCRIPTION
It was turned on regardless of hyperparams at forward pass, now is shut down anyway and either turned back up is it used to be or left as is if it was turned off in the first place.
Cf lines in e48cd740d641c87bb15bcad5976e914afc907f05 at the `entropic_dual_torch.py` file.