### PR TITLE
[TEST] Remove LFS-needing tests from test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,10 @@ doctest:
 	@echo "Style test:"
 	@hatch -e $(TEST_ENV) run env-docs:doc-test
 
-test: test_gen test_sk test_misc
+test: test_sk test_misc test_gen
+
+lfstests:
+	@pytest -v ./tests/torch_tests/test_regularized_linear_exact.py -W ignore::FutureWarning
 
 test_gen:
 	@echo "General tests:"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ python = "3.11"
 features = ["test"]
 
 [tool.hatch.envs.env-test.scripts]
-test-custom = "pytest -v ./tests/torch_tests -W ignore::FutureWarning"
+test-custom = "pytest -v ./tests/torch_tests/!(test_regularized_linear_exact.py) -W ignore::FutureWarning"
 test-sklearn = "pytest -v ./skwdro/tests -W ignore::FutureWarning"
 test-misc = "sh ./tests/misc/launchall.sh -W ignore::FutureWarning"
 ruff-test = "ruff check -q ./skwdro"


### PR DESCRIPTION
Removed by default, but can be launched through:
```shell
$ make lfstests
```