### PR TITLE
[FIX] Fixed the default value of the erm mode

### DIFF
--- a/skwdro/solvers/_dual_interfaces/_misc_dual_interfaces.py
+++ b/skwdro/solvers/_dual_interfaces/_misc_dual_interfaces.py
@@ -172,7 +172,7 @@ class _DualLossBase(nn.Module, ABC):
         self.erm_mode = True
         return super().eval()
 
-    def train(self, mode: bool = True):
+    def train(self, mode: bool = False):
         self.erm_mode = mode
         return super().train(mode)
 


### PR DESCRIPTION
On method `train` of the base for solver, the default value of `erm_mode` was incorrectly set to `True` instead of `False`.