### PR TITLE
Lbd in IS

### DIFF
--- a/examples/builtin_models/logistic_regression.py
+++ b/examples/builtin_models/logistic_regression.py
@@ -50,7 +50,7 @@ datasets.append((train_dataset, test_dataset))
 # WDRO classifiers
 # ~~~~~~~~~~~~~~~~
 
-rhos = [0.001, 0.01, 0.1]
+rhos = [10**i for i in range(-3, 0)]
 classifiers = []
 for rho in rhos:
     classifiers.append(LogisticRegression(rho=rho))

--- a/examples/builtin_models/utils/classifier_comparison.py
+++ b/examples/builtin_models/utils/classifier_comparison.py
@@ -100,6 +100,7 @@ def plot_classifier_comparison(names, classifiers, datasets, levels=10):
 				ax.set_title(name)
 			ax.text(xx.max() - .3, yy.min() + .3, f"Test Acc. {int(score*100)}%\nF1 {int(f1_sc*100)}%",
 					size=12, horizontalalignment='right', bbox=dict(facecolor='wheat', alpha=0.5))
+			print(f"Dataset {ds_cnt}, Classifier {name}: Test Acc. {int(score*100)}%, F1 {int(f1_sc*100)}%")
 			i += 1
 
 

--- a/skwdro/solvers/_dual_interfaces/_impsamp_interface.py
+++ b/skwdro/solvers/_dual_interfaces/_impsamp_interface.py
@@ -63,13 +63,15 @@ class _SampleDisplacer(_SampledDualLoss):
         # Assert type of results and get them returned
         return (
             normalize_just_vects(
-                grad_xi / inv_scale,
+                grad_xi,
                 threshold,
+                inv_scale,
                 dim=-1
             ),
             normalize_maybe_vects(
-                grad_xi_l / inv_scale,
+                grad_xi_l,
                 threshold,
+                inv_scale,
                 dim=-1
             )
         )

--- a/skwdro/solvers/_dual_interfaces/_impsamp_interface.py
+++ b/skwdro/solvers/_dual_interfaces/_impsamp_interface.py
@@ -51,6 +51,14 @@ class _SampleDisplacer(_SampledDualLoss):
         disps: (1, m, d), (1, m, d')
         """
         grad_xi, grad_xi_l = self.get_displacement_direction(xi, xi_labels)
+        # Compute the inverse scaling in the displacement
+        # Warnings:
+        # - .item() is important
+        # - the inverse of inv_scale must not be computed alone, 
+        #   it seems that it is crucial it is computed along with
+        #   the grads below
+        # - the point above takes care of numerical issues,
+        #   adding a floor to lambda causes other issues
         inv_scale = self._lam.item()
         # Assert type of results and get them returned
         return (

--- a/skwdro/solvers/_dual_interfaces/_impsamp_interface.py
+++ b/skwdro/solvers/_dual_interfaces/_impsamp_interface.py
@@ -23,11 +23,11 @@ class _SampleDisplacer(_SampledDualLoss):
             self,
             xi: pt.Tensor,
             xi_labels: Optional[pt.Tensor],
-            threshold: float = 1e10,
+            threshold: float = 1e10
     ) -> Tuple[pt.Tensor, Optional[pt.Tensor]]:
         r"""
         Thresholds the displacement of the samples to avoid numerical
-        instabilities
+        instabilities.
         See :py:method:`~_SampleDisplacer.get_optimal_displacement`.
         Yields :math:`\frac{\nabla_\xi L(\xi)}{\lambda}` with backprop
         algorithm.

--- a/skwdro/solvers/_dual_interfaces/_impsamp_interface.py
+++ b/skwdro/solvers/_dual_interfaces/_impsamp_interface.py
@@ -54,7 +54,7 @@ class _SampleDisplacer(_SampledDualLoss):
         # Compute the inverse scaling in the displacement
         # Warnings:
         # - .item() is important
-        # - the inverse of inv_scale must not be computed alone, 
+        # - the inverse of inv_scale must not be computed alone,
         #   it seems that it is crucial it is computed along with
         #   the grads below
         # - the point above takes care of numerical issues,

--- a/skwdro/solvers/_dual_interfaces/_impsamp_interface.py
+++ b/skwdro/solvers/_dual_interfaces/_impsamp_interface.py
@@ -23,11 +23,11 @@ class _SampleDisplacer(_SampledDualLoss):
             self,
             xi: pt.Tensor,
             xi_labels: Optional[pt.Tensor],
-            threshold: float = 1e10
+            threshold: float = 1e10,
     ) -> Tuple[pt.Tensor, Optional[pt.Tensor]]:
         r"""
         Thresholds the displacement of the samples to avoid numerical
-        instabilities.
+        instabilities
         See :py:method:`~_SampleDisplacer.get_optimal_displacement`.
         Yields :math:`\frac{\nabla_\xi L(\xi)}{\lambda}` with backprop
         algorithm.
@@ -51,15 +51,16 @@ class _SampleDisplacer(_SampledDualLoss):
         disps: (1, m, d), (1, m, d')
         """
         grad_xi, grad_xi_l = self.get_displacement_direction(xi, xi_labels)
+        inv_scale = self._lam.item()
         # Assert type of results and get them returned
         return (
             normalize_just_vects(
-                grad_xi / self._lam,
+                grad_xi / inv_scale,
                 threshold,
                 dim=-1
             ),
             normalize_maybe_vects(
-                grad_xi_l / self._lam,
+                grad_xi_l / inv_scale,
                 threshold,
                 dim=-1
             )

--- a/skwdro/solvers/utils.py
+++ b/skwdro/solvers/utils.py
@@ -43,11 +43,13 @@ def maybe_unsqueeze(
 def normalize_maybe_vects(
     tensor: Optional[pt.Tensor],
     threshold: float = 1.,
+    scaling: float = 1.,
     dim: int = 0
 ) -> Optional[pt.Tensor]:
     return None if tensor is None else normalize_just_vects(
         tensor,
         threshold,
+        scaling,
         dim
     )
 
@@ -55,11 +57,12 @@ def normalize_maybe_vects(
 def normalize_just_vects(
     tensor: pt.Tensor,
     threshold: float = 1.,
+    scaling: float = 1.,
     dim: int = 0
 ) -> pt.Tensor:
     n = pt.linalg.norm(tensor, dim=dim, keepdims=True)
     assert isinstance(n, pt.Tensor)
-    return tensor / n * pt.min(pt.tensor(threshold), n)
+    return tensor / n * pt.min(pt.tensor(threshold), n) / scaling
 
 
 class NoneGradError(ValueError):


### PR DESCRIPTION
Add a safeguard for lbd not to be added to the AD graph in IS. This seems to have significant impact on the shallow net example. I checked the other examples, and performance is at least the same as before, if not better.

As a note, the code is quite sensitive: computing `1/_lam` before it is multiplied with the gradients leads to numerical issues while replacing `_lam` by `min(1e-12, _lam)` leads to degraded performance on "linear"-like examples