### PR TITLE
FIX: Let Dirac code abide to Liskov substitution principle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,6 @@ test-custom = "pytest -v ./tests/torch_tests/!(test_regularized_linear_exact.py)
 test-sklearn = "pytest -v ./skwdro/tests -W ignore::FutureWarning"
 test-misc = "sh ./tests/misc/launchall.sh"
 ruff-test = "ruff check -q ./skwdro"
-# pycodestyle-test = "pycodestyle --exclude=skwdro/solvers/specific_solvers.py,skwdro/base/rho_tuners.py,skwdro/base/rho_tuners_computations.py --ignore=E501 skwdro/"
 pycodestyle-test = "pycodestyle --config=.pycodestyle/tox_all.ini skwdro/"
 pycodestyle-length-test = "pycodestyle --config=.pycodestyle/tox_501.ini skwdro/"
 mypy-test = "mypy skwdro/"


### PR DESCRIPTION
Should (!) fix the following error:
```sh
skwdro/distributions/dirac_distribution.py:29: error: Argument 1 of "expand" is incompatible with supertype "Distribution"; supertype defines the argument type as "Size | list[int] | tuple[int, ...]"  [override]
skwdro/distributions/dirac_distribution.py:29: note: This violates the Liskov substitution principle
skwdro/distributions/dirac_distribution.py:29: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
skwdro/distributions/dirac_distribution.py:53: error: Argument 1 of "rsample" is incompatible with supertype "Distribution"; supertype defines the argument type as "Size | list[int] | tuple[int, ...]"  [override]
skwdro/distributions/dirac_distribution.py:53: note: This violates the Liskov substitution principle
```