### PR TITLE
Attempt at avoiding crashes due to new numpy/sklearn versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,9 @@ classifiers = [
 ]
 
 dependencies = [
-    "numpy",
+    "numpy<2.0.0",
     "pandas",
-    "scikit-learn>=1.4",
+    "scikit-learn >=1.4, <1.5.2",
     "scipy",
     "cvxopt",
     "cvxpy",

--- a/skwdro/solvers/_dual_interfaces/dual_loss.py
+++ b/skwdro/solvers/_dual_interfaces/dual_loss.py
@@ -174,9 +174,6 @@ class _DualFormulation(_SampleDisplacer):
         else:
             self._lam.data.mul_(0.)
 
-
-class _DualLoss(_DualFormulation):
-
     @property
     def theta(self):
         """
@@ -202,3 +199,6 @@ class _DualLoss(_DualFormulation):
         """
         # return F.softplus(self._lam)
         return self._lam
+
+
+_DualLoss = _DualFormulation


### PR DESCRIPTION
Based on issues created by both breaking changes in API that affect the project.

- [Numpy related](https://stackoverflow.com/questions/78636947/a-module-that-was-compiled-using-numpy-1-x-cannot-be-run-in-numpy-2-0-0-as-it-ma) when `v>=2.0`
- [Scikit-Learn related](https://stackoverflow.com/questions/79290968/super-object-has-no-attribute-sklearn-tags) `v>=1.5.2` (it seems)

Shall be fixed by changes in our codebase later.
